### PR TITLE
[Fix] demo4 PrepareEngines wrong session

### DIFF
--- a/demo4-compare-with-vllm/frontend-double.py
+++ b/demo4-compare-with-vllm/frontend-double.py
@@ -44,7 +44,7 @@ def PrepareEngines():
     consume_stream(stream1)
     consume_stream(stream2)
     stream1 = session1.chat("Please just say 'hey': ")
-    stream2 = session1.chat("Please just say 'hey': ")
+    stream2 = session2.chat("Please just say 'hey': ")
     consume_stream(stream1)
     consume_stream(stream2)
 


### PR DESCRIPTION
Wrong session is used when sending the second prompt during engines preparation, 